### PR TITLE
feat: Reduce font size of "Bitte abgeben" text on timer expiration

### DIFF
--- a/script.js
+++ b/script.js
@@ -52,6 +52,7 @@ function tick() {
         timerInterval = null; // Set to null to indicate it's stopped
         timeDisplay.textContent = "Bitte abgeben";
         timeDisplay.classList.remove('time-warning', 'time-danger');
+        timeDisplay.classList.add('time-expired');
         // timerControls.style.display = 'none'; // Keep controls visible
     }
 }
@@ -63,7 +64,10 @@ function updateDisplay(seconds) {
     const formattedTime = `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
     timeDisplay.textContent = formattedTime;
 
-    timeDisplay.classList.remove('time-warning', 'time-danger');
+    // Clear all dynamic classes first
+    timeDisplay.classList.remove('time-warning', 'time-danger', 'time-expired');
+
+    // Then add the appropriate class back if needed
     if (initialTotalSeconds > 0) {
         const percentage = (seconds / initialTotalSeconds);
         if (percentage <= 0.10) {

--- a/style.css
+++ b/style.css
@@ -214,6 +214,12 @@ body {
 .time-warning { color: var(--warning-color); }
 .time-danger { color: var(--danger-color); }
 
+/* Stil für den abgelaufenen Timer-Text "Bitte abgeben" */
+#time-display.time-expired {
+    font-size: clamp(2rem, 12.5vw, 6rem); /* 50% der Originalgröße */
+    letter-spacing: normal; /* Normaler Buchstabenabstand für bessere Lesbarkeit */
+}
+
 #error-message {
     color: var(--danger-color);
     margin-top: 0.5rem;


### PR DESCRIPTION
When the timer expires, the font size of the "Bitte abgeben" text is now reduced by 50%.

This is achieved by:
- Adding a `time-expired` class to the time display element in `script.js` when the timer runs out.
- Adding a new CSS rule in `style.css` that targets the `time-expired` class to set the smaller font size and adjust letter spacing for readability.